### PR TITLE
Remove extract gem update --system command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
 matrix:
   allow_failures:
   - rvm: ruby-head  
-before_install: gem update --system
 services:
   - redis-server
 script:


### PR DESCRIPTION
This cause:
```
$ gem update --system
Updating rubygems-update
Fetching rubygems-update-3.1.0.gem
Successfully installed rubygems-update-3.1.0
Installing RubyGems 3.1.0
  Successfully built RubyGem
  Name: bundler
  Version: 2.1.0.pre.3
  File: bundler-2.1.0.pre.3.gem
bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-2.6.3/bin/bundle
Overwrite the executable? [yN]
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
The build has been terminated
``` on travis