### PR TITLE
Remove support of `codecov` gem

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,8 +44,6 @@ jobs:
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
-    - name: Check `simplecov` result coverage
-      run: cat coverage/.last_run.json | jq '.result.covered_percent' | grep -q '100'
     - name: Check source files using `rubocop`
       run: rubocop
     - name: Check that code 100% documented

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,6 +44,8 @@ jobs:
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
+    - name: Check `simplecov` result coverage
+      run: cat coverage/.last_run.json | jq '.result.covered_percent' | grep -q '100'
     - name: Check source files using `rubocop`
       run: rubocop
     - name: Check that code 100% documented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,9 @@
 ### Fixes
 
 * Do not call `bash` in Dockerfile CMD
+
+### Changes
+
+* Remove usage of `codecov`
+* Check `simplecov` coverage result in GitHub Actions
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,3 @@
 ### Changes
 
 * Remove usage of `codecov`
-* Check `simplecov` coverage result in GitHub Actions
-

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
 end
 
 group :test do
-  gem 'codecov', require: false
   gem 'rack-test'
   gem 'rspec'
+  gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,14 +4,9 @@ GEM
     ast (2.4.1)
     backports (3.18.1)
     childprocess (4.0.0)
-    codecov (0.1.17)
-      json
-      simplecov
-      url
     diff-lcs (1.4.2)
     docile (1.3.2)
     iniparse (1.5.0)
-    json (2.3.0)
     multi_json (1.14.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
@@ -74,19 +69,18 @@ GEM
       tilt (~> 2.0)
     tilt (2.0.10)
     unicode-display_width (1.7.0)
-    url (0.3.2)
     yard (0.9.25)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  codecov
   overcommit
   rack-test
   redis
   rspec
   rubocop
+  simplecov
   sinatra
   sinatra-contrib
   yard

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,6 @@
 require 'simplecov'
 SimpleCov.start
 
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
 require 'rack/test'
 require 'rspec'
 require_relative '../app.rb'


### PR DESCRIPTION
 `simplecov` already check coverage in in GitHub Actions